### PR TITLE
Fix string parsing

### DIFF
--- a/src/chunker.h
+++ b/src/chunker.h
@@ -37,6 +37,7 @@ struct chunker {
     } else {
       if      (c == '{') inside = ++depth >= min_depth;
       else if (c == '}') --depth;
+      else if (c == '"') quoted = true;
       else if (c == '\n') c = ' ';
     }
 


### PR DESCRIPTION
Until now it was completely ignoring strings. Inputs like this

    {"message": "this character } is part of string"}

would break it and split it in the middle of the string.

Fixes #1 